### PR TITLE
Add Waveshare Ethernet Firmware for Add-on boards

### DIFF
--- a/.github/workflows/build_esphome_firmware.yml
+++ b/.github/workflows/build_esphome_firmware.yml
@@ -76,6 +76,24 @@ jobs:
         id: set-files
         run: |
           source ./scripts/configs.sh
+
+          required_waveshare_configs=(
+            "6chan_energy_meter_main_ethernet_waveshare.yaml"
+            "6chan_energy_meter_1-addon_ethernet_waveshare.yaml"
+            "6chan_energy_meter_2-addons_ethernet_waveshare.yaml"
+            "6chan_energy_meter_3-addons_ethernet_waveshare.yaml"
+            "6chan_energy_meter_4-addons_ethernet_waveshare.yaml"
+            "6chan_energy_meter_5-addons_ethernet_waveshare.yaml"
+            "6chan_energy_meter_6-addons_ethernet_waveshare.yaml"
+          )
+
+          for config in "${required_waveshare_configs[@]}"; do
+            if [[ -z "${CONFIG_META[$config]}" ]]; then
+              echo "Missing required config in scripts/configs.sh: $config"
+              exit 1
+            fi
+          done
+
           version="${{ steps.esphome_version.outputs.version }}"
           force_build="${{ github.event.inputs.force_build }}"
           force_build="${force_build:-false}"

--- a/index.html
+++ b/index.html
@@ -121,12 +121,15 @@
         const groups = {
           GDO: [],
           Meter: [],
-          Ethernet: []
+          Ethernet: [],
+          EthernetWaveshare: []
         };
       
         products.forEach(p => {
           if (p.productId.includes('gdo')) {
             groups.GDO.push(p);
+          } else if (p.productId.includes('ethernet_waveshare')) {
+            groups.EthernetWaveshare.push(p);
           } else if (p.productId.includes('ethernet')) {
             groups.Ethernet.push(p);
           } else {
@@ -146,10 +149,13 @@
         const displayNames = {
           GDO: "Garage Door Opener",
           Meter: "6 Channel Meter",
-          Ethernet: "6 Channel Meter Ethernet (for Lilygo T-ETH-Lite ESP32S3)"
+          Ethernet: "6 Channel Meter Ethernet (Lilygo T-ETH-Lite ESP32S3)",
+          EthernetWaveshare: "6 Channel Meter Ethernet Waveshare (ESP32-S3-ETH)"
         };
         
         for (const [groupName, products] of Object.entries(groups)) {
+          if (products.length === 0) continue;
+
           const header = document.createElement("h3");
           header.textContent = displayNames[groupName] || groupName;
           productList.appendChild(header);

--- a/scripts/configs.sh
+++ b/scripts/configs.sh
@@ -16,13 +16,19 @@ CONFIG_META["6chan_energy_meter_5-addons.yaml"]="CircuitSetup 6 Channel Energy M
 CONFIG_META["6chan_energy_meter_6-addons.yaml"]="CircuitSetup 6 Channel Energy Meter Main + 6 Add-ons|ESP32"
 
 CONFIG_META["6chan_energy_meter_main_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter Ethernet|ESP32_S3"
-CONFIG_META["6chan_energy_meter_main_ethernet_ws.yaml"]="CircuitSetup 6 Channel Energy Meter Ethernet WS|ESP32_S3"
+CONFIG_META["6chan_energy_meter_main_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter Ethernet Waveshare|ESP32_S3"
 CONFIG_META["6chan_energy_meter_1-addon_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter + 1 Add-on Ethernet|ESP32_S3"
+CONFIG_META["6chan_energy_meter_1-addon_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter + 1 Add-on Ethernet Waveshare|ESP32_S3"
 CONFIG_META["6chan_energy_meter_2-addons_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter + 2 Add-ons Ethernet|ESP32_S3"
+CONFIG_META["6chan_energy_meter_2-addons_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter + 2 Add-ons Ethernet Waveshare|ESP32_S3"
 CONFIG_META["6chan_energy_meter_3-addons_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter + 3 Add-ons Ethernet|ESP32_S3"
+CONFIG_META["6chan_energy_meter_3-addons_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter + 3 Add-ons Ethernet Waveshare|ESP32_S3"
 CONFIG_META["6chan_energy_meter_4-addons_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter + 4 Add-ons Ethernet|ESP32_S3"
+CONFIG_META["6chan_energy_meter_4-addons_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter + 4 Add-ons Ethernet Waveshare|ESP32_S3"
 CONFIG_META["6chan_energy_meter_5-addons_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter + 5 Add-ons Ethernet|ESP32_S3"
+CONFIG_META["6chan_energy_meter_5-addons_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter + 5 Add-ons Ethernet Waveshare|ESP32_S3"
 CONFIG_META["6chan_energy_meter_6-addons_ethernet.yaml"]="CircuitSetup 6 Channel Energy Meter + 6 Add-ons Ethernet|ESP32_S3"
+CONFIG_META["6chan_energy_meter_6-addons_ethernet_waveshare.yaml"]="CircuitSetup 6 Channel Energy Meter + 6 Add-ons Ethernet Waveshare|ESP32_S3"
 
 # Flat list of config file names
 CONFIG_LIST=("${!CONFIG_META[@]}")


### PR DESCRIPTION
### Motivation
- The build flow must reference the canonical Waveshare configs so variants are not silently omitted or miscategorized.

### Description
- Removed the legacy `6chan_energy_meter_main_ethernet_ws.yaml` mapping and ensured the canonical `*_ethernet_waveshare.yaml` entries are present in `scripts/configs.sh`.
- Updated `index.html` product grouping to add a new `EthernetWaveshare` group, a separate display name "6 Channel Meter Ethernet Waveshare (ESP32-S3-ETH)", and logic to skip empty groups so headers only render when products exist.
- Kept non-Waveshare Ethernet products in the existing Ethernet group with a clearer Lilygo label so the two families are presented separately.
- The firmware build workflow includes checks to assert required Waveshare config keys are present before selecting files to build so missing metadata fails early. 